### PR TITLE
Drop UNIT_ prefix for percentage constant (home-assistant/core/pull#39383)

### DIFF
--- a/custom_components/yr/sensor.py
+++ b/custom_components/yr/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     PRESSURE_HPA,
     SPEED_METERS_PER_SECOND,
     TEMP_CELSIUS,
-    UNIT_PERCENTAGE,
+    PERCENTAGE,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -49,12 +49,12 @@ SENSOR_TYPES = {
     "windGust": ["Wind gust", SPEED_METERS_PER_SECOND, None],
     "pressure": ["Pressure", PRESSURE_HPA, DEVICE_CLASS_PRESSURE],
     "windDirection": ["Wind direction", DEGREE, None],
-    "humidity": ["Humidity", UNIT_PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "fog": ["Fog", UNIT_PERCENTAGE, None],
-    "cloudiness": ["Cloudiness", UNIT_PERCENTAGE, None],
-    "lowClouds": ["Low clouds", UNIT_PERCENTAGE, None],
-    "mediumClouds": ["Medium clouds", UNIT_PERCENTAGE, None],
-    "highClouds": ["High clouds", UNIT_PERCENTAGE, None],
+    "humidity": ["Humidity", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
+    "fog": ["Fog", PERCENTAGE, None],
+    "cloudiness": ["Cloudiness", PERCENTAGE, None],
+    "lowClouds": ["Low clouds", PERCENTAGE, None],
+    "mediumClouds": ["Medium clouds", PERCENTAGE, None],
+    "highClouds": ["High clouds", PERCENTAGE, None],
     "dewpointTemperature": [
         "Dewpoint temperature",
         TEMP_CELSIUS,

--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -409,9 +409,9 @@ views:
     title: Desk
     icon: "mdi:monitor"
     badges:
-      - device_tracker.disrupted_mbp_wifi
+      - device_tracker.disrupted_mbp
       - device_tracker.disrupted_ipad
-      - device_tracker.disrupted_iphone_wifi
+      - device_tracker.disrupted_iphone
     cards:
       - type: entities
         show_header_toggle: false
@@ -434,9 +434,8 @@ views:
           - sensor.printer
           - sensor.printer_black_toner_cartridge
           - sensor.printer_black_image_drum_unit
-          - binary_sensor.macbookpro_power
-          - binary_sensor.macbookpro_active
-          - sensor.macbookpro_usage_today
+          - binary_sensor.disrupted_mbp_active
+          - sensor.disrupted_mbp_usage_today
       - type: entities
         title: Uni
         entities:


### PR DESCRIPTION
See https://github.com/home-assistant/core/pull/39383 for reference

to be merged with the upcoming v0.115 release

